### PR TITLE
Add defined(MA_APPLE_MOBILE) guard around AVAudioSessionCategory code

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -20744,6 +20744,7 @@ ma_result ma_context_uninit__coreaudio(ma_context* pContext)
     return MA_SUCCESS;
 }
 
+#if defined(MA_APPLE_MOBILE)
 static AVAudioSessionCategory ma_to_AVAudioSessionCategory(ma_ios_session_category category)
 {
     /* The "default" and "none" categories are treated different and should not be used as an input into this function. */
@@ -20762,6 +20763,7 @@ static AVAudioSessionCategory ma_to_AVAudioSessionCategory(ma_ios_session_catego
         default:                                      return AVAudioSessionCategoryAmbient;
     }
 }
+#endif
 
 ma_result ma_context_init__coreaudio(const ma_context_config* pConfig, ma_context* pContext)
 {


### PR DESCRIPTION
Gets the dev branch building for other platforms again (I know you were going to get to this but making the PR in case others are using the dev branch)

`ma_to_AVAudioSessionCategory` is only used within `MA_APPLE_MOBILE` code, so I've added a `#defined()` guard around it to enable compiling for other platforms. (Without it I get unknown type errors building for desktop)