### PR TITLE
Return proper result when fopen() fails.

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -6813,6 +6813,7 @@ MA_API ma_result ma_fopen(FILE** ppFile, const char* pFilePath, const char* pOpe
         if (result == MA_SUCCESS) {
             return MA_ERROR;   /* Just a safety check to make sure we never ever return success when pFile == NULL. */
         }
+        return result;
     }
 #endif
 


### PR DESCRIPTION
There's a bug in `ma_fopen()` on non-MSVC configurations - even if `fopen()` fails, `MA_SUCCESS` is being returned which further causes crashes in decoders which try to interpret an invalid pointer. Seems like you missed one `return` statement, so I'm adding it in this pull request.