### PR TITLE
memmove with NULL is undefined behavior

### DIFF
--- a/extras/dr_mp3.h
+++ b/extras/dr_mp3.h
@@ -2653,7 +2653,9 @@ static drmp3_uint32 drmp3_decode_next_frame_ex__callbacks(drmp3* pMP3, drmp3d_sa
             size_t bytesRead;
 
             /* First we need to move the data down. */
-            memmove(pMP3->pData, pMP3->pData + pMP3->dataConsumed, pMP3->dataSize);
+            if (pMP3->pData) {
+                memmove(pMP3->pData, pMP3->pData + pMP3->dataConsumed, pMP3->dataSize);
+            }
             pMP3->dataConsumed = 0;
 
             if (pMP3->dataCapacity < DRMP3_DATA_CHUNK_SIZE) {


### PR DESCRIPTION
Fixes a warning from ubsan (this path gets hit from ma_decoder_init_file_mp3 when reading the first to check that it is a valid stream).